### PR TITLE
chore: allow more versions of used packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "engines": {
-    "node": ">=14 <17"
+    "node": ">=14 <18"
   },
   "dependencies": {
     "@directus/sdk": "^9.0.0-rc.95",
@@ -35,7 +35,7 @@
     "@typescript-eslint/eslint-plugin": "^4.32.0",
     "@typescript-eslint/parser": "^4.32.0",
     "eslint": "^7.32.0",
-    "eslint-import-resolver-webpack": "^0.13.1",
+    "eslint-import-resolver-webpack": "^0.13.2",
     "eslint-plugin-import": "^2.24.2",
     "eslint-plugin-react": "^7.26.1",
     "file-loader": "^6.2.0",


### PR DESCRIPTION
Allow more node versions and bump version of eslint-import-resolver-webpack