### PR TITLE
Remove header tabs for Q-Phase and queerbeats

### DIFF
--- a/src/sections/Header.tsx
+++ b/src/sections/Header.tsx
@@ -10,8 +10,6 @@ export default function Header(): ReactElement {
   const navigationEntries: NavigationEntry[] = [
     { destinationUrl: "/", label: "Startseite" },
     { destinationUrl: "/contact", label: "Kontakt" },
-    { destinationUrl: "/q-phase-21", label: "Q-Phase" },
-    { destinationUrl: "/queerbeats", label: "queerbeats" },
   ];
 
   const router = useRouter();


### PR DESCRIPTION
This removes stated tabs in the header. If we have no capacities to update the pages, we should at least remove the links to prevent confusion.